### PR TITLE
Disable fail-fast for terraform workflow

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -40,6 +40,7 @@ jobs:
       terraform: ${{ steps.output.outputs.stdout }}
 
     strategy:
+      fail-fast: false
       matrix:
         workspace: ${{ fromJson(inputs.workspaces) }}
       max-parallel: ${{ inputs.action == 'apply' && 1 || 10 }}


### PR DESCRIPTION
Description of `fail-fast`:
> When set to `true`, GitHub cancels all in-progress jobs if any matrix job fails. Default: `true`

If a plan or apply fails for an individual workspace, we don't want all jobs to be cancelled because of it.