### PR TITLE
Dos 79 add static security checks terraform pipeline

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Checkov
         env:
           SAT: ${{ inputs.static_analysis_tool }}
-        if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') & contains( ${{ fromJson(env.SAT) }}, 'checkov')
+        if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') & contains(env.SAT, 'checkov')
         run: |
           pip3 install checkov
           checkov --quiet --compact -s -d .
@@ -87,7 +87,7 @@ jobs:
       - name: tfsec
         env:
           SAT: ${{ inputs.static_analysis_tool }}
-        if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') & contains( ${{ fromJson(env.SAT) }}, 'tfsec')
+        if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') & contains(env.SAT), 'tfsec')
         run: |
           brew install tfsec
           tfsec -s .

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -78,16 +78,16 @@ jobs:
 
       - name: Checkov
         env:
-          SAT: inputs.static_analysis_tool
-        if: env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate' && env.SAT == 'checkov'
+          SAT: ${{ inputs.static_analysis_tool }}
+        if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') && env.SAT == 'checkov'
         run: |
           pip3 install checkov
           checkov -s -d .
 
       - name: tfsec
         env:
-          SAT: inputs.static_analysis_tool
-        if: env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate' && env.SAT == 'tfsec'
+          SAT: ${{ inputs.static_analysis_tool }}
+        if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') && env.SAT == 'tfsec'
         run: |
           brew install tfsec
           tfsec -s .

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Checkov
         env:
           SAT: ${{ inputs.static_analysis_tool }}
-        if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') && contains( ${{ fromJson(env.SAT) }}, 'checkov')
+        if: env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate' && contains( ${{ fromJson(env.SAT) }}, 'checkov')
         run: |
           pip3 install checkov
           checkov -s -d .
@@ -87,7 +87,7 @@ jobs:
       - name: tfsec
         env:
           SAT: ${{ inputs.static_analysis_tool }}
-        if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') && contains( ${{ fromJson(env.SAT) }}, 'tfsec')
+        if: env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate' && contains( ${{ fromJson(env.SAT) }}, 'tfsec')
         run: |
           brew install tfsec
           tfsec -s .

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -10,7 +10,7 @@ on:
         required: false
         type: string
       static_analysis_tool:
-        default: none
+        default: '["none"]'
         required: false
         type: string
       working-directory:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Checkov
         env:
           SAT: ${{ inputs.static_analysis_tool }}
-        if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') && ( ${{ fromJson(env.SAT) }} == 'checkov')
+        if: env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate' & ${{ fromJson(env.SAT) }} == 'checkov'
         run: |
           pip3 install checkov
           checkov --quiet --compact -s -d .
@@ -87,7 +87,7 @@ jobs:
       - name: tfsec
         env:
           SAT: ${{ inputs.static_analysis_tool }}
-        if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') && ( ${{ fromJson(env.SAT) }} == 'tfsec')
+        if: env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate' & ${{ fromJson(env.SAT) }} == 'tfsec'
         run: |
           brew install tfsec
           tfsec -s .

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -90,7 +90,7 @@ jobs:
         if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') && contains(env.SAT, 'tfsec')
         run: |
           brew install tfsec
-          tfsec -s .
+          tfsec -s --sort-severity --gif .
 
       - name: Initialise
         run: terraform init -input=false

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Checkov
         env:
-          SAT: ${{ fromJson(inputs.static_analysis_tool) }}
+          SAT: ${{ inputs.static_analysis_tool }}
         if: env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate' && env.SAT == 'checkov'
         run: |
           pip3 install checkov

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Checkov
         env:
           SAT: ${{ inputs.static_analysis_tool }}
-        if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') & contains(env.SAT, 'checkov')
+        if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') && contains(env.SAT, 'checkov')
         run: |
           pip3 install checkov
           checkov --quiet --compact -s -d .
@@ -87,7 +87,7 @@ jobs:
       - name: tfsec
         env:
           SAT: ${{ inputs.static_analysis_tool }}
-        if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') & contains(env.SAT, 'tfsec')
+        if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') && contains(env.SAT, 'tfsec')
         run: |
           brew install tfsec
           tfsec -s .

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -78,8 +78,8 @@ jobs:
 
       - name: Checkov
         env:
-          SAT: ${{ inputs.static_analysis_tool }}
-        if: env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate' && contains( ${{ fromJson(env.SAT) }}, 'checkov')
+          SAT: ${{ fromJson(inputs.static_analysis_tool) }}
+        if: env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate' && env.SAT == 'checkov'
         run: |
           pip3 install checkov
           checkov -s -d .
@@ -87,7 +87,7 @@ jobs:
       - name: tfsec
         env:
           SAT: ${{ inputs.static_analysis_tool }}
-        if: env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate' && contains( ${{ fromJson(env.SAT) }}, 'tfsec')
+        if: env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate' && env.SAT == 'tfsec'
         run: |
           brew install tfsec
           tfsec -s .

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Checkov
         env:
           SAT: ${{ inputs.static_analysis_tool }}
-        if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') && env.SAT == 'checkov'
+        if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') && ${{ fromJson(env.SAT) }} == 'checkov'
         run: |
           pip3 install checkov
           checkov -s -d .
@@ -87,7 +87,7 @@ jobs:
       - name: tfsec
         env:
           SAT: ${{ inputs.static_analysis_tool }}
-        if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') && env.SAT == 'tfsec'
+        if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') && ${{ fromJson(env.SAT) }} == 'tfsec'
         run: |
           brew install tfsec
           tfsec -s .

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -87,7 +87,7 @@ jobs:
       - name: tfsec
         env:
           SAT: ${{ input.static_analysis_tool }}
-        if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') && (env.SAT == 'both' || env.SAT == 'tfsec')
+        if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') && contains( ${{ fromJson(env.SAT) }}, 'tfsec')
         run: |
           brew install tfsec
           tfsec .

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -10,7 +10,7 @@ on:
         required: false
         type: string
       static_analysis_tool:
-        default: none
+        default: "none"
         required: false
         type: string
       working-directory:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Checkov
         env:
           SAT: ${{ inputs.static_analysis_tool }}
-        if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') && ${{ fromJson(env.SAT) }} == 'checkov'
+        if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') && ( ${{ fromJson(env.SAT) }} == 'checkov')
         run: |
           pip3 install checkov
           checkov -s -d .
@@ -87,7 +87,7 @@ jobs:
       - name: tfsec
         env:
           SAT: ${{ inputs.static_analysis_tool }}
-        if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') && ${{ fromJson(env.SAT) }} == 'tfsec'
+        if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') && ( ${{ fromJson(env.SAT) }} == 'tfsec')
         run: |
           brew install tfsec
           tfsec -s .

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -10,7 +10,7 @@ on:
         required: false
         type: string
       static_analysis_tool:
-        default: "none"
+        default: '["none"]'
         required: false
         type: string
       working-directory:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -10,7 +10,7 @@ on:
         required: false
         type: string
       static_analysis_tool:
-        default: '["none"]'
+        default: none
         required: false
         type: string
       working-directory:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -82,7 +82,7 @@ jobs:
         if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') && ( ${{ fromJson(env.SAT) }} == 'checkov')
         run: |
           pip3 install checkov
-          checkov -s -d .
+          checkov --quiet --compact -s -d .
 
       - name: tfsec
         env:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -87,7 +87,7 @@ jobs:
       - name: tfsec
         env:
           SAT: ${{ inputs.static_analysis_tool }}
-        if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') & contains(env.SAT), 'tfsec')
+        if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') & contains(env.SAT, 'tfsec')
         run: |
           brew install tfsec
           tfsec -s .

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Checkov
         env:
-          SAT: ${{ inputs.static_analysis_tool }}
+          SAT: inputs.static_analysis_tool
         if: env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate' && env.SAT == 'checkov'
         run: |
           pip3 install checkov
@@ -86,7 +86,7 @@ jobs:
 
       - name: tfsec
         env:
-          SAT: ${{ inputs.static_analysis_tool }}
+          SAT: inputs.static_analysis_tool
         if: env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate' && env.SAT == 'tfsec'
         run: |
           brew install tfsec

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Checkov
         env:
           SAT: ${{ inputs.static_analysis_tool }}
-        if: env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate' & ${{ fromJson(env.SAT) }} == 'checkov'
+        if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') & contains( ${{ fromJson(env.SAT) }}, 'checkov')
         run: |
           pip3 install checkov
           checkov --quiet --compact -s -d .
@@ -87,7 +87,7 @@ jobs:
       - name: tfsec
         env:
           SAT: ${{ inputs.static_analysis_tool }}
-        if: env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate' & ${{ fromJson(env.SAT) }} == 'tfsec'
+        if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') & contains( ${{ fromJson(env.SAT) }}, 'tfsec')
         run: |
           brew install tfsec
           tfsec -s .

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -9,6 +9,11 @@ on:
         default: "1.0.0"
         required: false
         type: string
+      static_analysis_tool:
+        default: none
+        default: '["checkov","tfsec","tflint"]'
+        required: false
+        type: string
       working-directory:
         default: "./"
         required: false
@@ -71,6 +76,22 @@ jobs:
       - name: Lint
         if: env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate'
         run: terraform fmt -check -diff -recursive
+
+      - name: Checkov
+        env:
+          SAT: ${{ input.static_analysis_tool }}
+        if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') && contains( ${{ fromJson(env.SAT) }}, 'checkov')
+        run: |
+          pip3 install checkov
+          checkov -d .
+
+      - name: tfsec
+        env:
+          SAT: ${{ input.static_analysis_tool }}
+        if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') && (env.SAT == 'both' || env.SAT == 'tfsec')
+        run: |
+          brew install tfsec
+          tfsec .
 
       - name: Initialise
         run: terraform init -input=false

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -11,7 +11,6 @@ on:
         type: string
       static_analysis_tool:
         default: none
-        default: '["checkov","tfsec","tflint"]'
         required: false
         type: string
       working-directory:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Checkov
         env:
-          SAT: ${{ input.static_analysis_tool }}
+          SAT: ${{ inputs.static_analysis_tool }}
         if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') && contains( ${{ fromJson(env.SAT) }}, 'checkov')
         run: |
           pip3 install checkov
@@ -86,7 +86,7 @@ jobs:
 
       - name: tfsec
         env:
-          SAT: ${{ input.static_analysis_tool }}
+          SAT: ${{ inputs.static_analysis_tool }}
         if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') && contains( ${{ fromJson(env.SAT) }}, 'tfsec')
         run: |
           brew install tfsec

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -82,7 +82,7 @@ jobs:
         if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') && contains( ${{ fromJson(env.SAT) }}, 'checkov')
         run: |
           pip3 install checkov
-          checkov -d .
+          checkov -s -d .
 
       - name: tfsec
         env:
@@ -90,7 +90,7 @@ jobs:
         if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') && contains( ${{ fromJson(env.SAT) }}, 'tfsec')
         run: |
           brew install tfsec
-          tfsec .
+          tfsec -s .
 
       - name: Initialise
         run: terraform init -input=false


### PR DESCRIPTION
Add tfsec and checkov to the terraform reusable workflow, set to not fail on errors/warnings so we can start getting an idea of the impact of having it run against our terraform code.