### PR TITLE
Remove deprecated flag for tfsec

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -90,7 +90,7 @@ jobs:
         if: (env.TF_ACTION == 'plan' || env.TF_ACTION == 'validate') && contains(env.SAT, 'tfsec')
         run: |
           brew install tfsec
-          tfsec -s --sort-severity --gif .
+          tfsec -s --gif .
 
       - name: Initialise
         run: terraform init -input=false


### PR DESCRIPTION
With the release of v1.0.0 of tfsec, the `--sort-severity` flag has been removed.

https://github.com/aquasecurity/tfsec/releases/tag/v1.0.0 for reference.