### PR TITLE
Bump Terraform from 1.0.0 to 1.1.7

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -6,7 +6,7 @@ on:
         required: false
         type: string
       terraform_version:
-        default: "1.0.0"
+        default: "1.1.7"
         required: false
         type: string
       static_analysis_tool:


### PR DESCRIPTION
Bumps Terraform version in [.github/workflows/terraform.yml](.github/workflows/terraform.yml) from 1.0.0 to 1.1.7.

<details>
  <summary>Release notes</summary>
  From [https://github.com/hashicorp/terraform/releases/tag/v1.1.7](https://github.com/hashicorp/terraform/releases/tag/v1.1.7).

  ## 1.1.7 (March 02, 2022)

BUG FIXES:

* `terraform show -json`: Improve performance for deeply-nested object values. The previous implementation was accidentally quadratic, which could result in very long execution time for generating JSON plans, and timeouts on Terraform Cloud and Terraform Enterprise. ([#30561](https://github.com/hashicorp/terraform/issues/30561))
* cloud: Update go-slug for terraform.tfstate exclusion to prevent a user from getting an error
    after migrating state to TFC.
</details>