### PR TITLE
Bump Terraform from 1.1.7 to 1.1.8

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -6,7 +6,7 @@ on:
         required: false
         type: string
       terraform_version:
-        default: "1.1.7"
+        default: "1.1.8"
         required: false
         type: string
       static_analysis_tool:


### PR DESCRIPTION
Bumps Terraform version in [.github/workflows/terraform.yml](.github/workflows/terraform.yml) from 1.1.7 to 1.1.8.

<details>
  <summary>Release notes</summary>
  From <a href="https://github.com/hashicorp/terraform/releases/tag/v1.1.8">https://github.com/hashicorp/terraform/releases/tag/v1.1.8</a>.

  ## 1.1.8 (April 07, 2022)

BUG FIXES:

* cli: Fix missing identifying attributes (e.g. "id", "name") when displaying plan diffs with nested objects. ([#30685](https://github.com/hashicorp/terraform/issues/30685))
* functions: Fix error when `sum()` function is called with a collection of string-encoded numbers, such as `sum(["1", "2", "3"])`. ([#30684](https://github.com/hashicorp/terraform/issues/30684))
* When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier. ([#30766](https://github.com/hashicorp/terraform/issues/30766))
* Terraform will no longer crash in the `terraform apply` phase if an error occurs during backend configuration. ([#30780](https://github.com/hashicorp/terraform/pull/30780))
</details>