### PR TITLE
Bump Terraform from 1.1.8 to 1.1.9

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -6,7 +6,7 @@ on:
         required: false
         type: string
       terraform_version:
-        default: "1.1.8"
+        default: "1.1.9"
         required: false
         type: string
       static_analysis_tool:


### PR DESCRIPTION
Bumps Terraform version in [.github/workflows/terraform.yml](.github/workflows/terraform.yml) from 1.1.8 to 1.1.9.

<details>
  <summary>Release notes</summary>
  From <a href="https://github.com/hashicorp/terraform/releases/tag/v1.1.9">https://github.com/hashicorp/terraform/releases/tag/v1.1.9</a>.

  ## 1.1.9 (April 20, 2022)

BUG FIXES:

* cli: Fix crash when using sensitive values in sets. ([#30825](https://github.com/hashicorp/terraform/issues/30825))
* cli: Fix double-quoted map keys when rendering a diff. ([#30855](https://github.com/hashicorp/terraform/issues/30855))
* core: Prevent errors when handling a data source with incompatible schema changes ([#30830](https://github.com/hashicorp/terraform/issues/30830))

ENHANCEMENTS:
* cli: Terraform now supports [run tasks](https://www.terraform.io/cloud-docs/workspaces/settings/run-tasks), a Terraform Cloud integration for executing remote operations, for the post plan stage of a run.
</details>