### PR TITLE
Bump Terraform from 1.2.0 to 1.2.1

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -6,7 +6,7 @@ on:
         required: false
         type: string
       terraform_version:
-        default: "1.2.0"
+        default: "1.2.1"
         required: false
         type: string
       static_analysis_tool:


### PR DESCRIPTION
Bumps Terraform version in [.github/workflows/terraform.yml](.github/workflows/terraform.yml) from 1.2.0 to 1.2.1.

<details>
  <summary>Release notes</summary>
  From <a href="https://github.com/hashicorp/terraform/releases/tag/v1.2.1">https://github.com/hashicorp/terraform/releases/tag/v1.2.1</a>.

  ## 1.2.1 (May 23, 2022)

BUG FIXES:

* SSH provisioner connections fail when using signed `ed25519` keys ([#31092](https://github.com/hashicorp/terraform/issues/31092))
* Crash with invalid module source ([#31060](https://github.com/hashicorp/terraform/issues/31060))
* Incorrect "Module is incompatible with count, for_each, and depends_on" error when a provider is nested within a module along with a sub-module using `count` or `for_each` ([#31091](https://github.com/hashicorp/terraform/issues/31091))
</details>