### PR TITLE
Bump Terraform from 1.2.1 to 1.2.2

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -6,7 +6,7 @@ on:
         required: false
         type: string
       terraform_version:
-        default: "1.2.1"
+        default: "1.2.2"
         required: false
         type: string
       static_analysis_tool:


### PR DESCRIPTION
Bumps Terraform version in [.github/workflows/terraform.yml](.github/workflows/terraform.yml) from 1.2.1 to 1.2.2.

<details>
  <summary>Release notes</summary>
  From <a href="https://github.com/hashicorp/terraform/releases/tag/v1.2.2">https://github.com/hashicorp/terraform/releases/tag/v1.2.2</a>.

  ## 1.2.2 (June 01, 2022)

ENHANCEMENTS:

* Invalid `-var` arguments with spaces between the name and value now have an improved error message ([#30985](https://github.com/hashicorp/terraform/issues/30985))

BUG FIXES:

* Terraform now hides invalid input values for sensitive root module variables when generating error diagnostics ([#30552](https://github.com/hashicorp/terraform/issues/30552))
* Fixed crash on CLI autocomplete ([#31160](https://github.com/hashicorp/terraform/issues/31160))
* The "Configuration contains unknown values" error message now includes attribute paths ([#31111](https://github.com/hashicorp/terraform/issues/31111))

</details>