### PR TITLE
Bump Terraform from 1.2.2 to 1.2.3

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -6,7 +6,7 @@ on:
         required: false
         type: string
       terraform_version:
-        default: "1.2.2"
+        default: "1.2.3"
         required: false
         type: string
       static_analysis_tool:


### PR DESCRIPTION
Bumps Terraform version in [.github/workflows/terraform.yml](.github/workflows/terraform.yml) from 1.2.2 to 1.2.3.

<details>
  <summary>Release notes</summary>
  From <a href="https://github.com/hashicorp/terraform/releases/tag/v1.2.3">https://github.com/hashicorp/terraform/releases/tag/v1.2.3</a>.

  ## 1.2.3 (June 15, 2022)

UPGRADE NOTES:

* The following remote state backends are now marked as deprecated, and are
  planned to be removed in a future Terraform release. These backends have
  been unmaintained since before Terraform v1.0, and may contain known bugs,
  outdated packages, or security vulnerabilities.
  - artifactory
  - etcd
  - etcdv3
  - manta
  - swift

BUG FIXES:

* Missing check for error diagnostics in GetProviderSchema could result in panic ([#31184](https://github.com/hashicorp/terraform/issues/31184))
* Module registries returning X-Terraform-Get locations with no URL would error with "no getter available for X-Terraform-Get source protocol" ([#31237](https://github.com/hashicorp/terraform/issues/31237))
* Fix crash from concurrent operation on shared set of resource instance dependencies ([#31246](https://github.com/hashicorp/terraform/issues/31246))
* backend/cos: `tencentcloud-terraform-lock` tag was not removed in all cases ([#31223](https://github.com/hashicorp/terraform/issues/31223))
</details>