### PR TITLE
Bump Terraform from 1.2.3 to 1.2.5

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -6,7 +6,7 @@ on:
         required: false
         type: string
       terraform_version:
-        default: "1.2.3"
+        default: "1.2.5"
         required: false
         type: string
       static_analysis_tool:


### PR DESCRIPTION
Bumps Terraform version in [.github/workflows/terraform.yml](.github/workflows/terraform.yml) from 1.2.3 to 1.2.5.

<details>
  <summary>Release notes</summary>
  From <a href="https://github.com/hashicorp/terraform/releases/tag/v1.2.5">https://github.com/hashicorp/terraform/releases/tag/v1.2.5</a>.

  ## 1.2.5 (July 13, 2022)

BUG FIXES:

* Report correct error message when a prerelease field is included in the `required_version` global constraint. ([#31331](https://github.com/hashicorp/terraform/issues/31331))
* Fix case when extra blank lines were inserted into the plan for unchanged blocks. ([#31330](https://github.com/hashicorp/terraform/issues/31330))
</details>